### PR TITLE
[Feat] #4 - 앱 진입 플로우 뼈대 구현

### DIFF
--- a/YaguBogu/YaguBogu/App/Application/SceneDelegate.swift
+++ b/YaguBogu/YaguBogu/App/Application/SceneDelegate.swift
@@ -3,40 +3,24 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    var appCoordinator: AppCoordinator?
 
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
+
+        let nav = UINavigationController()
+        appCoordinator = AppCoordinator(navigationController: nav)
+        appCoordinator?.start()
+
         let window = UIWindow(windowScene: windowScene)
-        
-        window.rootViewController = HomeViewController()
-        
+        window.rootViewController = nav
         window.makeKeyAndVisible()
-        
+
         self.window = window
     }
-
-    func sceneDidDisconnect(_ scene: UIScene) {
-
-    }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-
-    }
-
-    func sceneDidEnterBackground(_ scene: UIScene) {
-
-    }
-
-
 }
 

--- a/YaguBogu/YaguBogu/App/Base/BaseCoordinator.swift
+++ b/YaguBogu/YaguBogu/App/Base/BaseCoordinator.swift
@@ -1,3 +1,0 @@
-//  BaseCoordinator.swift
-
-

--- a/YaguBogu/YaguBogu/App/Coordinator/AppCoordinator.swift
+++ b/YaguBogu/YaguBogu/App/Coordinator/AppCoordinator.swift
@@ -1,1 +1,28 @@
-// AppCoordinator.swift
+import UIKit
+import RxSwift
+
+final class AppCoordinator: BaseCoordinator {
+
+    private let disposeBag = DisposeBag()
+
+    override func start() {
+        showSplash()
+    }
+
+    private func showSplash() {
+
+        let vm = SplashViewModel()
+        let vc = SplashViewController(viewModel: vm)
+
+        // '스플래시 끝남' 이벤트 구독
+        vm.finishTrigger
+            .subscribe(onNext: { [weak self] in
+                print("스플래시가 끝남")
+                // 다음 동작은 이후 브랜치에서 추가
+            })
+            .disposed(by: disposeBag)
+
+        navigationController.setViewControllers([vc], animated: false)
+    }
+}
+

--- a/YaguBogu/YaguBogu/App/Coordinator/BaseCoordinator.swift
+++ b/YaguBogu/YaguBogu/App/Coordinator/BaseCoordinator.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+class BaseCoordinator {
+    var navigationController: UINavigationController
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    func start() { }
+}
+

--- a/YaguBogu/YaguBogu/App/Coordinator/TabBarCoordinator.swift
+++ b/YaguBogu/YaguBogu/App/Coordinator/TabBarCoordinator.swift
@@ -1,3 +1,0 @@
-//  TabBarCoordinator.swift
-
-

--- a/YaguBogu/YaguBogu/Features/Splash/View/SplashViewController.swift
+++ b/YaguBogu/YaguBogu/Features/Splash/View/SplashViewController.swift
@@ -1,0 +1,30 @@
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class SplashViewController: UIViewController {
+
+    private let disposeBag = DisposeBag()
+    
+    let viewModel: SplashViewModel
+
+    init(viewModel: SplashViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // 애니메이션이 끝나면
+        viewModel.splashDidFinish()
+    }
+}
+

--- a/YaguBogu/YaguBogu/Features/Splash/ViewModel/SplashViewModel.swift
+++ b/YaguBogu/YaguBogu/Features/Splash/ViewModel/SplashViewModel.swift
@@ -1,0 +1,14 @@
+import RxSwift
+import RxCocoa
+
+final class SplashViewModel {
+
+    // 화면이 끝났다는 신호를 방출함
+    let finishTrigger = PublishRelay<Void>()
+    
+    // splashDidFinish는 스플래시 뷰컨트롤러에서 쓰임
+    func splashDidFinish() {
+        finishTrigger.accept(())
+    }
+}
+


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #4 

MVVM-C 패턴 기반으로 `앱 최초실행`->`스플래시 실행종료`까지의 뼈대를 만들었습니다.

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

스플래시 화면은 UI나 애니메이션 없이, 스플래시 뷰컨트롤러의 viewDidAppear()에서 종료신호만 전달하도록 구현했습니다. 

print("스플래시가 끝남") 부분은 임시 처리이며, 
와이어프레임 확정 이후 UI, 애니메이션을 추가할 때 프린트문 제거예정입니다.

# 관련 개발로그

[스플래시화면 표시까지의 파일 호출 순서](https://www.notion.so/2afb000d70fa80759665ccc3d8f238b2?source=copy_link)
[스플래시화면 표시까지 패턴적용](https://www.notion.so/2afb000d70fa809a8d3eca4bb7370266?source=copy_link)

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
