### PR TITLE
[Design] #8 - 구단 선택화면 UI 구현

### DIFF
--- a/YaguBogu/YaguBogu.xcodeproj/project.pbxproj
+++ b/YaguBogu/YaguBogu.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = YaguBogu/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "야구보구";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
@@ -221,6 +222,7 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = YaguBogu/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "야구보구";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";

--- a/YaguBogu/YaguBogu/App/Base/BaseViewController.swift
+++ b/YaguBogu/YaguBogu/App/Base/BaseViewController.swift
@@ -7,18 +7,29 @@ class BaseViewController: UIViewController{
     
     var disposeBag = DisposeBag()
     
+    private let bottomView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
         setupConstraints()
+        view.backgroundColor = UIColor(cgColor: CGColor(red: 248/255, green: 248/255, blue: 250/255, alpha: 1.0))
     }
     
     func configureUI(){
-        
+        view.addSubview(bottomView)
     }
     
     func setupConstraints(){
-        
+        bottomView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalToSuperview()
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-30)
+        }
     }
     
 }

--- a/YaguBogu/YaguBogu/Features/SelectTeam/View/Cell/SelectTeamCell.swift
+++ b/YaguBogu/YaguBogu/Features/SelectTeam/View/Cell/SelectTeamCell.swift
@@ -1,0 +1,80 @@
+
+import Foundation
+import UIKit
+
+
+class SelectTeamCell: UICollectionViewCell{
+    static let identifier = "SelectTeamCell"
+    
+    private let logoImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    private var teamNameLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 12, weight: .semibold)
+        return label
+    }()
+    
+    private var cityLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 10, weight: .semibold)
+        return label
+    }()
+    
+    private lazy var labelStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [teamNameLabel, cityLabel])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 2
+        return stack
+    }()
+    
+    private lazy var mainStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [logoImage, labelStackView])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 15
+        return stack
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        configuerView()
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI(){
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 16
+        contentView.addSubview(mainStackView)
+    }
+    
+    private func configuerView(){
+        logoImage.snp.makeConstraints { make in
+            make.height.equalTo(contentView.snp.width).multipliedBy(0.4)
+        }
+        
+        mainStackView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(10)
+        }
+    }
+    
+    func configure(with team: TeamInfo){
+        let transTeamLabel = team.name
+        let koreanTeamLabel = BaseBallNameTranslator.getKoreanName(for: transTeamLabel)
+        logoImage.image = UIImage(named: team.teamLogo)
+        teamNameLabel.text = koreanTeamLabel
+        cityLabel.text = team.city
+    }
+}

--- a/YaguBogu/YaguBogu/Features/SelectTeam/View/TeamHeaderView.swift
+++ b/YaguBogu/YaguBogu/Features/SelectTeam/View/TeamHeaderView.swift
@@ -1,0 +1,28 @@
+import UIKit
+import SnapKit
+
+class TeamHeaderView: UICollectionReusableView {
+    static let identifier = "TeamHeaderView"
+    
+    let subTitleLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.text = "응원하는 구단팀을 선택하고, 구장 날씨를 확인하세요\n한번 선택하신 구장은 변경하실 수 없습니다"
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .systemGray
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(subTitleLabel)
+        
+        subTitleLabel.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(UIEdgeInsets(top: 8, left: 24, bottom: 16, right: 24))
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/YaguBogu/YaguBogu/Features/SelectTeam/View/TeamViewController.swift
+++ b/YaguBogu/YaguBogu/Features/SelectTeam/View/TeamViewController.swift
@@ -1,0 +1,172 @@
+import UIKit
+import CoreLocation
+import RxSwift
+import RxRelay
+import SnapKit
+
+class TeamViewController: BaseViewController {
+    private let viewModel = TeamViewModel()
+    
+    private let headerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(cgColor: CGColor(red: 248/255, green: 248/255, blue: 250/255, alpha: 1.0))
+        return view
+    }()
+    private let bottomView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 16
+        return view
+    }()
+    
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
+        collectionView.backgroundColor = UIColor(cgColor: CGColor(red: 248/255, green: 248/255, blue: 250/255, alpha: 1.0))
+        return collectionView
+    }()
+    
+    let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "관심 야구 팀 선택"
+        label.textAlignment = .center
+        return label
+    }()
+    
+    
+    let selectButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("선택완료", for: .normal)
+        button.backgroundColor = UIColor(cgColor: CGColor(red: 219/255, green: 219/255, blue: 219/255, alpha: 1.0))
+        button.layer.cornerRadius = 12
+        return button
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupCollectionView()
+        bind()
+        viewModel.loadMergeData()
+        
+    }
+    
+    override func configureUI(){
+        super.configureUI()
+        [titleLabel].forEach{
+            headerView.addSubview($0)
+        }
+        
+        [selectButton].forEach{
+            bottomView.addSubview($0)
+        }
+        
+        [headerView,collectionView,bottomView].forEach{
+            view.addSubview($0)
+        }
+    }
+    
+    override func setupConstraints(){
+        super.setupConstraints()
+        headerView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(20)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().offset(-16)
+        }
+        
+        bottomView.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalToSuperview()
+        }
+        
+        selectButton.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(16)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().offset(-10)
+            make.height.equalTo(57)
+        }
+        
+        collectionView.snp.makeConstraints { make in
+            make.top.equalTo(headerView.snp.bottom)
+            make.bottom.equalTo(bottomView.snp.top)
+            make.leading.trailing.equalToSuperview()
+            
+        }
+    }
+    
+    private func bind() {
+        viewModel.teams
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] _ in
+                self?.collectionView.reloadData()
+            }).disposed(by: disposeBag)
+    }
+    
+    private func setupCollectionView(){
+        collectionView.dataSource = self
+        collectionView.register(SelectTeamCell.self, forCellWithReuseIdentifier: SelectTeamCell.identifier)
+        collectionView.register(TeamHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: TeamHeaderView.identifier)
+    }
+    
+    private func createLayout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0/2.0),
+                                              heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                               heightDimension: .fractionalWidth(1.0/2.0))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, repeatingSubitem: item, count: 2)
+        group.interItemSpacing = .fixed(15)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 12
+        
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0 , leading: 12, bottom: 0, trailing: 12)
+        
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                heightDimension: .estimated(60))
+        let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top)
+        
+        section.boundarySupplementaryItems = [sectionHeader]
+        
+        let layout = UICollectionViewCompositionalLayout(section: section)
+        return layout
+    }
+}
+
+extension TeamViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return viewModel.teams.value.count
+    }
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectTeamCell.identifier, for: indexPath) as? SelectTeamCell else {
+            return UICollectionViewCell()
+        }
+        let teamInfo = viewModel.teams.value[indexPath.item]
+        cell.configure(with: teamInfo)
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        guard kind == UICollectionView.elementKindSectionHeader,
+              let header = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: TeamHeaderView.identifier,
+                for: indexPath) as? TeamHeaderView else {
+            return UICollectionReusableView()
+        }
+        
+        return header
+    }
+}
+
+
+#Preview{
+    TeamViewController()
+}

--- a/YaguBogu/YaguBogu/Utils/Json/ExtraTeamModel.json
+++ b/YaguBogu/YaguBogu/Utils/Json/ExtraTeamModel.json
@@ -7,7 +7,7 @@
             "latitude" : "37.51201894088975",
             "longtitude" : "127.0718969383121",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         },
         {
             "teamId": "Hanwha Eagles",
@@ -16,7 +16,7 @@
             "latitude" : "36.316066596569165",
             "longtitude" : "127.43167645403133",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         },
         {
             "teamId": "KIA Tigers",
@@ -25,7 +25,7 @@
             "latitude" : "35.168143901359784",
             "longtitude" : "126.8891423364501",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         },
         {
             "teamId": "Kiwoom Heroes",
@@ -34,7 +34,7 @@
             "latitude" : "37.49848034218344",
             "longtitude" : "126.86716482656504",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         },
         {
             "teamId": "KT Wiz Suwon",
@@ -43,7 +43,7 @@
             "latitude" : "37.29966537879378",
             "longtitude" : "127.00977034570677",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         },
         {
             "teamId": "LG Twins",
@@ -52,7 +52,7 @@
             "latitude" : "37.51201894088975",
             "longtitude" : "127.0718969383121",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         },
         {
             "teamId": "Lotte Giants",
@@ -61,7 +61,7 @@
             "latitude" : "35.1940238473883",
             "longtitude" : "129.06143988969237",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         },
         {
             "teamId": "NC Dinos",
@@ -70,7 +70,7 @@
             "latitude" : "35.22263093553172",
             "longtitude" : "128.58223816267258",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         },
         {
             "teamId": "Samsung Lions",
@@ -79,7 +79,7 @@
             "latitude" : "35.8410120804932",
             "longtitude" : "128.68163963151713",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         },
         {
             "teamId": "SSG Landers",
@@ -88,7 +88,7 @@
             "latitude" : "37.43695806700958",
             "longtitude" : "126.69324804173549",
             "defalutCharacter": "Character/Default",
-            "teamLogo" : "TeamLogo/Doosan"
+            "teamLogo" : "Doosan"
         }
     ]
 }


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #8 

BaseController에 배경색 추가
CompositionalLayout으로 2열 그리드 형태로 레이아웃 구성
스크롤 가능한 헤더 구현
TeamViewModel의 데이터를 바인딩하여 레이아웃 구성

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

이후 폰트 및 크기를 수정해야 합니다.
버튼에 대한 예외처리와 선택한 데이터를 홈 화면에 전달하는 기능을 구현해야합니다.
홈 화면으로 이동할 때 사용할 Coordinator도 구현해야 합니다.

# 관련 개발로그

[구단 선택화면 화면 구현 어떤 방식으로 제작할까](https://www.notion.so/2b0b000d70fa809798b8e9808496af6b?source=copy_link)

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
