### PR TITLE
[Feat] #22 - 온보딩 화면에 Coordinator 적용

### DIFF
--- a/YaguBogu/YaguBogu.xcodeproj/project.pbxproj
+++ b/YaguBogu/YaguBogu.xcodeproj/project.pbxproj
@@ -188,7 +188,6 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = YaguBogu/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "야구보구";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
@@ -222,7 +221,6 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = YaguBogu/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "야구보구";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";

--- a/YaguBogu/YaguBogu/App/Application/AppCoordinator.swift
+++ b/YaguBogu/YaguBogu/App/Application/AppCoordinator.swift
@@ -23,12 +23,28 @@ final class AppCoordinator: BaseCoordinator {
                 if let savedTeam = TeamDataUserDefaults.shared.getSelectedTeam(){
                     self?.showHome(with: savedTeam)
                 } else {
-                    self?.showSelectTeam()
+                    self?.showOnboarding { [weak self] in
+                        self?.showSelectTeam()
+                    }
                 }
             })
             .disposed(by: disposeBag)
 
         navigationController.setViewControllers([vc], animated: false)
+    }
+    
+    private func showOnboarding(completion: @escaping () -> Void) {
+        let onboardingCoordinator = OnboardingCoordinator(navigationController: navigationController)
+        
+        onboardingCoordinator.didFinish = { [ weak self, weak onboardingCoordinator] in
+            guard let self = self, let onboardingCoordinator = onboardingCoordinator else { return }
+            
+            self.removeChild(onboardingCoordinator)
+            
+            completion()
+        }
+        addChild(onboardingCoordinator)
+        onboardingCoordinator.start()
     }
     
     private func showSelectTeam() {

--- a/YaguBogu/YaguBogu/Features/Onboarding/Coordinator/OnboardingCoordinator.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/Coordinator/OnboardingCoordinator.swift
@@ -1,1 +1,20 @@
+import SwiftUI
+import UIKit
 
+final class OnboardingCoordinator: BaseCoordinator {
+    
+    var didFinish: (() -> Void)?
+    
+    override func start() {
+        let viewModel = OnboardingViewModel()
+        let view = OnboardingContainerView(viewModel: viewModel)
+        
+        viewModel.onFlowCompleted = { [weak self] in
+            self?.didFinish?()
+        }
+        
+        let hostingVC = UIHostingController(rootView: view)
+        
+        navigationController.setViewControllers([hostingVC], animated: true)
+    }
+}

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingContainerView.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingContainerView.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
 struct OnboardingContainerView: View {
-    @StateObject var viewModel = OnboardingViewModel()
+    @StateObject var viewModel: OnboardingViewModel
+    
+    init(viewModel: OnboardingViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
     
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -16,14 +20,11 @@ struct OnboardingContainerView: View {
                     case 0: OnboardingView1()
                     case 1: OnboardingView2()
                     case 2: OnboardingView3()
-                    // 홈 뷰 추가
-//                    case 3:
                     default: EmptyView()
                     }
                     Spacer()
                         .frame(height: 119)
                 }
-                .padding(.top, 165)
             }
             .ignoresSafeArea(.container, edges: .bottom)
             
@@ -40,8 +41,4 @@ struct OnboardingContainerView: View {
             }
         }
     }
-}
-
-#Preview {
-    OnboardingContainerView()
 }

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView1.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView1.swift
@@ -13,7 +13,7 @@ struct OnboardingView1: View {
             
             Text("야구장 날씨가 궁금하시죠?")
                 .font(.system(size: 28, weight: .semibold))
-                                .padding(10)
+                .padding(10)
             
             Text("좋아하는 구단을 선택하고,")
                 .font(.system(size: 16, weight: .medium))
@@ -23,5 +23,6 @@ struct OnboardingView1: View {
                 .font(.system(size: 16, weight: .medium))
                 .foregroundColor(Color(red: 143/255, green: 143/255, blue: 143/255))
         }
+        .padding(.top, 165)
     }
 }

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView2.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView2.swift
@@ -20,5 +20,6 @@ struct OnboardingView2: View {
                 .resizable()
                 .frame(width: 200, height: 200)
         }
+        .padding(.top, 165)
     }
 }

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView3.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView3.swift
@@ -5,8 +5,8 @@ struct OnboardingView3: View {
     var body: some View {
         VStack {
             HStack {
-                    Text("경기일정\n한눈에 모아봤어요.")
-                        .font(.system(size: 28, weight: .semibold))
+                Text("경기일정\n한눈에 모아봤어요.")
+                    .font(.system(size: 28, weight: .semibold))
                 
                 Image("Onboarding3")
                     .resizable()
@@ -20,5 +20,6 @@ struct OnboardingView3: View {
                 .frame(width: 295, height: 304)
                 .cornerRadius(12)
         }
+        .padding(.top, 80)
     }
 }


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #22 

- MVVM 구조를 MVVM-C 구조로 수정했습니다.
- `AppCoordinator`에 `showOnboarding()` 을 추가하고, 온보딩 완료 시 다음 화면(showSelectTeam) 호출하게 했습니다.
- SwiftUI 화면을 Coordinator 패턴과 연결하려면, SwiftUI 뷰를 UIKit의 `UINavigationController` 스택에 넣어야 합니다. 
이를 위해 `UIHostingController`로 SwiftUI 뷰를 감싸서 `UINavigationController`에서 push/pop이 가능하도록 구현했습니다.

```swift
let hostingVC = UIHostingController(rootView: view)
        
navigationController.setViewControllers([hostingVC], animated: true)
```

<br>

![Simulator Screen Recording - iPhone 16 Pro - 2025-11-20 at 19 06 19](https://github.com/user-attachments/assets/70c37335-d54a-46be-b244-fa0655e9781e)



# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

OnboardingView1, 2, 3 파일에서 UI 관련 padding 값을 수정했습니다.


# 관련 개발로그
[온보딩 화면 Coordinator 적용](https://www.notion.so/Coordinator-2b1b000d70fa80469c66f701841f5af9)

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
