### PR TITLE
[Feat] #18 - 하단탭바 로직 구현

### DIFF
--- a/YaguBogu/YaguBogu/App/Application/AppCoordinator.swift
+++ b/YaguBogu/YaguBogu/App/Application/AppCoordinator.swift
@@ -18,10 +18,9 @@ final class AppCoordinator: BaseCoordinator {
         vm.finishTrigger
             .subscribe(onNext: { [weak self] in
                 print("스플래시가 끝남")
-                // 다음 동작은 이후 브랜치에서 추가
                 
                 if let savedTeam = TeamDataUserDefaults.shared.getSelectedTeam(){
-                    self?.showHome(with: savedTeam)
+                    self?.showTabBar(with: savedTeam)
                 } else {
                     self?.showSelectTeam()
                 }
@@ -41,7 +40,7 @@ final class AppCoordinator: BaseCoordinator {
                 TeamDataUserDefaults.shared.saveSelectedTeam(selectTeam)
                 
                 self?.removeChild(teamCoordinator)
-                self?.showHome(with: selectTeam)
+                self?.showTabBar(with: selectTeam)
             })
             .disposed(by: disposeBag)
         
@@ -50,12 +49,14 @@ final class AppCoordinator: BaseCoordinator {
     }
     
     
-    private func showHome(with team: TeamInfo){
-        let homeVM = HomeViewModel(team: team)
-        let homeVC = HomeViewController(viewModel: homeVM)
-        
-        
-        navigationController.setViewControllers([homeVC], animated: true)
+    private func showTabBar(with team: TeamInfo) {
+        let tabBarCoordinator = TabBarCoordinator(
+            navigationController: navigationController,
+            team: team
+        )
+
+        addChild(tabBarCoordinator)
+        tabBarCoordinator.start()
     }
 }
 

--- a/YaguBogu/YaguBogu/Features/Record/RecordViewController.swift
+++ b/YaguBogu/YaguBogu/Features/Record/RecordViewController.swift
@@ -1,0 +1,7 @@
+import UIKit
+import SnapKit
+
+final class RecordViewController: BaseViewController {
+
+}
+

--- a/YaguBogu/YaguBogu/Features/Record/RecordViewModel.swift
+++ b/YaguBogu/YaguBogu/Features/Record/RecordViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+final class RecordViewModel {
+
+}
+

--- a/YaguBogu/YaguBogu/Features/Schedule/ScheduleViewController.swift
+++ b/YaguBogu/YaguBogu/Features/Schedule/ScheduleViewController.swift
@@ -1,0 +1,7 @@
+import UIKit
+import SnapKit
+
+final class ScheduleViewController: BaseViewController {
+
+}
+

--- a/YaguBogu/YaguBogu/Features/Schedule/ScheduleViewModel.swift
+++ b/YaguBogu/YaguBogu/Features/Schedule/ScheduleViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+final class ScheduleViewModel {
+
+}
+

--- a/YaguBogu/YaguBogu/Features/TabBar/TabBarController.swift
+++ b/YaguBogu/YaguBogu/Features/TabBar/TabBarController.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+final class TabBarController: UITabBarController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tabBar.backgroundColor = .white
+        tabBar.tintColor = .primary
+        tabBar.unselectedItemTintColor = .gray03
+    }
+}
+

--- a/YaguBogu/YaguBogu/Features/TabBar/TabBarCoordinator.swift
+++ b/YaguBogu/YaguBogu/Features/TabBar/TabBarCoordinator.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+final class TabBarCoordinator: BaseCoordinator {
+
+    private let team: TeamInfo
+
+    init(navigationController: UINavigationController, team: TeamInfo) {
+        self.team = team
+        super.init(navigationController: navigationController)
+    }
+
+    override func start() {
+        let tabBarController = TabBarController()
+
+        // 홈 탭
+        let homeVM = HomeViewModel(team: team)
+        let homeVC = HomeViewController(viewModel: homeVM)
+        let homeNav = UINavigationController(rootViewController: homeVC)
+        homeNav.tabBarItem = UITabBarItem(title: "홈", image: UIImage(systemName: "house"), tag: 0)
+
+        // 경기일정 탭
+        let scheduleVC = ScheduleViewController()
+        let scheduleNav = UINavigationController(rootViewController: scheduleVC)
+        scheduleNav.tabBarItem = UITabBarItem(title: "경기 일정", image: UIImage(systemName: "calendar"), tag: 1)
+
+        // 직관기록 탭
+        let recordVC = RecordViewController()
+        let recordNav = UINavigationController(rootViewController: recordVC)
+        recordNav.tabBarItem = UITabBarItem(title: "직관 기록", image: UIImage(systemName: "list.bullet.rectangle"), tag: 2)
+
+        tabBarController.viewControllers = [homeNav, scheduleNav, recordNav]
+
+        navigationController.setViewControllers([tabBarController], animated: true)
+    }
+    
+    
+
+
+
+}
+


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #18 

`스플래시 → 팀 선택 여부에 따라서 → showHome으로 HomeVC 를 push`
의 흐름에서,

```
AppCoordinator
   ↓
showSplash()
   ↓
SplashViewController.finishTrigger
   ↓
showTabBar(team)
   ↓
TabBarCoordinator.start()
   ↓
TabBarController (rootViewController)
       ├── 홈 
       └── 경기일정 
       └── 직관기록 

```
으로 변경시켰습니다.

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

하단탭의 아이콘이 SFSymbol 에는 없는 아이콘이어서, 이미지로 들어가야할것같습니다.
현재는 유사한 SFSymbol로 넣었고, 이후 브랜치에서 이미지로 변환할 예정입니다.

# 관련 개발로그
[하단탭바 구현](https://www.notion.so/2b0b000d70fa80a6b6e2fe2b81cff3a3?source=copy_link)


# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
