### PR TITLE
[Feat] #32 - 앱 최초진입 시 접근권한 모달 표시

### DIFF
--- a/YaguBogu/YaguBogu/Features/Onboarding/Coordinator/OnboardingCoordinator.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/Coordinator/OnboardingCoordinator.swift
@@ -8,13 +8,23 @@ final class OnboardingCoordinator: BaseCoordinator {
     override func start() {
         let viewModel = OnboardingViewModel()
         let view = OnboardingContainerView(viewModel: viewModel)
-        
+
         viewModel.onFlowCompleted = { [weak self] in
             self?.didFinish?()
         }
-        
+
         let hostingVC = UIHostingController(rootView: view)
-        
         navigationController.setViewControllers([hostingVC], animated: true)
+
+        DispatchQueue.main.async { [weak self] in
+            self?.showPermissionSheet(on: hostingVC)
+        }
+    }
+
+    private func showPermissionSheet(on viewController: UIViewController) {
+        let viewModel = PermissionBottomSheetViewModel()
+        let permissionVC = PermissionBottomSheet(viewModel: viewModel)
+        permissionVC.modalPresentationStyle = .overFullScreen
+        viewController.present(permissionVC, animated: true)
     }
 }

--- a/YaguBogu/YaguBogu/Features/PermissionModal/View/PermissionBottomSheet.swift
+++ b/YaguBogu/YaguBogu/Features/PermissionModal/View/PermissionBottomSheet.swift
@@ -1,0 +1,140 @@
+import UIKit
+import SnapKit
+
+final class PermissionBottomSheet: UIViewController {
+
+    private let viewModel: PermissionBottomSheetViewModel
+
+    private let dimmedView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        view.alpha = 0
+        return view
+    }()
+
+    private let sheetView: PermissionBottomSheetView
+    
+    private let sheetHeight: CGFloat
+
+
+    private var sheetInitialY: CGFloat = 0
+
+    init(viewModel: PermissionBottomSheetViewModel) {
+        self.viewModel = viewModel
+        self.sheetView = PermissionBottomSheetView(viewModel: viewModel)
+
+        let figmaHeightRatio: CGFloat = 1126.0 / 2622.0
+        self.sheetHeight = UIScreen.main.bounds.height * figmaHeightRatio
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("에러메세지")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupLayout()
+        setupGesture()
+
+        sheetView.closeButton.addTarget(self, action: #selector(animateDismiss), for: .touchUpInside)
+        sheetView.confirmButton.addTarget(self, action: #selector(animateDismiss), for: .touchUpInside)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        animatePresent()
+    }
+
+
+    private func setupLayout() {
+        view.addSubview(dimmedView)
+        dimmedView.snp.makeConstraints { $0.edges.equalToSuperview() }
+
+        view.addSubview(sheetView)
+        sheetView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(sheetHeight)
+            $0.bottom.equalToSuperview().offset(sheetHeight)
+        }
+    }
+
+
+    private func setupGesture() {
+        // 딤드뷰 클릭하면 닫힘
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleDimmedTap))
+        dimmedView.addGestureRecognizer(tap)
+
+        // 핸들바랑 전체 시트 제스처
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+        sheetView.addGestureRecognizer(panGesture)
+    }
+
+    @objc private func handleDimmedTap() {
+        animateDismiss()
+    }
+
+
+    private func animatePresent() {
+        UIView.animate(withDuration: 0.2) {
+            self.dimmedView.alpha = 1
+        }
+
+        sheetView.snp.updateConstraints {
+            $0.bottom.equalToSuperview()
+        }
+
+        UIView.animate(
+            withDuration: 0.3,
+            delay: 0,
+            options: .curveEaseOut
+        ) {
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    @objc private func animateDismiss() {
+        sheetView.snp.updateConstraints {
+            $0.bottom.equalToSuperview().offset(self.sheetHeight)
+        }
+
+        UIView.animate(
+            withDuration: 0.25,
+            delay: 0,
+            options: .curveEaseIn
+        ) {
+            self.view.layoutIfNeeded()
+            self.dimmedView.alpha = 0
+        } completion: { _ in
+            self.dismiss(animated: false)
+        }
+    }
+
+    // 핸들팬 제스처
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        let translationY = gesture.translation(in: view).y
+
+        switch gesture.state {
+        case .changed:
+            // 아래로만 이동
+            if translationY > 0 {
+                sheetView.transform = CGAffineTransform(translationX: 0, y: translationY)
+            }
+
+        case .ended:
+            if translationY > 120 {
+                animateDismiss()
+            } else {
+                // 원래 자리로 복귀
+                UIView.animate(withDuration: 0.2) {
+                    self.sheetView.transform = .identity
+                }
+            }
+
+        default: break
+        }
+    }
+
+}
+

--- a/YaguBogu/YaguBogu/Features/PermissionModal/View/PermissionBottomSheetView.swift
+++ b/YaguBogu/YaguBogu/Features/PermissionModal/View/PermissionBottomSheetView.swift
@@ -1,0 +1,178 @@
+import UIKit
+import SnapKit
+
+final class PermissionBottomSheetView: UIView {
+
+    private let viewModel: PermissionBottomSheetViewModel
+
+    private let handleBar: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 196/255, green: 196/255, blue: 199/255, alpha: 1)
+        view.layer.cornerRadius = 2.5
+        return view
+    }()
+
+    let closeButton: UIButton = {
+        let btn = UIButton()
+        let config = UIImage.SymbolConfiguration(pointSize: 25, weight: .regular)
+        btn.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
+        btn.tintColor = UIColor(red: 0x38/255, green: 0x38/255, blue: 0x38/255, alpha: 1)
+        return btn
+    }()
+
+    private let iconContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 247/255, green: 247/255, blue: 247/255, alpha: 1)
+        view.layer.cornerRadius = 25
+        return view
+    }()
+
+    private let iconImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.image = UIImage(systemName: "photo")
+        iv.tintColor = .appBlack
+        return iv
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "AppleSDGothicNeo-SemiBold", size: 17)
+        label.textColor = .appBlack
+        return label
+    }()
+
+    private let mainDescriptionLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .appBlack
+        label.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 16)
+        return label
+    }()
+
+    private let divider: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 230/255, green: 230/255, blue: 230/255, alpha: 1)
+        return view
+    }()
+
+    private let subDescriptionLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .gray06
+        label.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 14)
+        label.numberOfLines = 0
+        return label
+    }()
+
+    let confirmButton: UIButton = {
+        let btn = UIButton()
+        btn.setTitle("확인", for: .normal)
+        btn.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-SemiBold", size: 16)
+        btn.backgroundColor = .primary
+        btn.layer.cornerRadius = 12
+        return btn
+    }()
+
+
+    init(viewModel: PermissionBottomSheetViewModel) {
+        self.viewModel = viewModel
+        super.init(frame: .zero)
+        setupUI()
+        setupLayout()
+        bind(viewModel)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("에러메세지")
+    }
+
+
+    private func setupUI() {
+        backgroundColor = .white
+        layer.cornerRadius = 35
+        clipsToBounds = true
+
+        addSubview(handleBar)
+        addSubview(closeButton)
+        addSubview(iconContainer)
+        iconContainer.addSubview(iconImageView)
+        addSubview(titleLabel)
+        addSubview(mainDescriptionLabel)
+        addSubview(divider)
+        addSubview(subDescriptionLabel)
+        addSubview(confirmButton)
+    }
+
+
+    private func setupLayout() {
+
+
+        handleBar.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(5)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(36)
+            $0.height.equalTo(5)
+        }
+
+
+        closeButton.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().offset(-20)
+            $0.width.height.equalTo(36)
+        }
+
+
+        iconContainer.snp.makeConstraints {
+            $0.top.equalTo(handleBar.snp.bottom).offset(76)
+            $0.leading.equalToSuperview().offset(24)
+            $0.width.height.equalTo(55)
+        }
+
+        iconImageView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(26)
+            $0.height.equalTo(22)
+        }
+
+
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(iconContainer.snp.top)
+            $0.leading.equalTo(iconContainer.snp.trailing).offset(16)
+            $0.trailing.lessThanOrEqualTo(closeButton.snp.leading).offset(-16)
+        }
+
+
+        mainDescriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
+            $0.leading.equalTo(titleLabel)
+            $0.trailing.equalToSuperview().offset(-24)
+        }
+
+
+        divider.snp.makeConstraints {
+            $0.top.equalTo(iconContainer.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(1)
+        }
+
+
+        subDescriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(divider.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(24)
+        }
+
+
+        confirmButton.snp.makeConstraints {
+            $0.top.greaterThanOrEqualTo(subDescriptionLabel.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(57)
+            $0.bottom.equalToSuperview().offset(-40)
+        }
+    }
+
+
+    private func bind(_ viewModel: PermissionBottomSheetViewModel) {
+        titleLabel.text = viewModel.titleText
+        mainDescriptionLabel.text = viewModel.descriptionText
+        subDescriptionLabel.text = viewModel.subDescriptionText
+    }
+}
+

--- a/YaguBogu/YaguBogu/Features/PermissionModal/ViewModel/PermissionBottomSheetViewModel.swift
+++ b/YaguBogu/YaguBogu/Features/PermissionModal/ViewModel/PermissionBottomSheetViewModel.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+final class PermissionBottomSheetViewModel {
+
+    let titleText: String = "앨범"
+    let descriptionText: String = "파일 첨부 또는 파일 저장을 위해 사용"
+    
+    let subDescriptionText: String = 
+"""
+선택적 접근 권한은 해당 기능의 실행시 동의 여부를 선택할 수 있으며, 동의하지 않아도 정상적인 앱 사용이 가능합니다.
+"""
+
+}
+


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #32 

앱을 최초실행하는 유저에게 보여지는 접근권한 안내 모달입니다. 
온보딩 페이지1의 화면으로 넘어감과 동시에 자동으로 올라오는 형태이고, 
`딤드뷰 눌렀을 때`/`핸들바`/`클로즈버튼`/`확인버튼`에 액션을 달아놨습니다.


<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-24 at 11 54 05 1" src="https://github.com/user-attachments/assets/87752353-4b4e-47c9-a81f-be1b1e93c660" />

<br>

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

- 이후에 글자간격/반응형 레이아웃 세부조정을 진행할 예정입니다.. 현재 컴포넌트들 비율값은 피그마 디자인 값과 동일하게 맞춘 상태입니다.

- 온보딩 페이지1 화면에서 띄우는 모달이라 온보딩코디네이터에 붙였습니다! 개별 코디네이터로 분리가 필요해보이면 다시 수정하겠습니다.

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
