### PR TITLE
[Feat] #37 - 온보딩 화면 반응형 레이아웃으로 수정

### DIFF
--- a/YaguBogu/YaguBogu/Features/Onboarding/View/Components/NextButtonView.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/Components/NextButtonView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct NextButtonView: View {
+    let w: CGFloat
     let buttonColor = Color(red: 255/255, green: 114/255, blue: 116/255)
-    
     var action: () -> Void
     
     var body: some View {
@@ -12,8 +12,8 @@ struct NextButtonView: View {
             }) {
                 Text("다음")
                     .font(.custom("AppleSDGothicNeo-SemiBold", size: 16))
-                    .foregroundColor(.white)
-                    .frame(width: 343, height: 57)
+                    .foregroundColor(Color(UIColor.appWhite))
+                    .frame(width: (343 / 402) * w, height: (57 / 402) * w)
             }
         .background(buttonColor)
         .cornerRadius(12)

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/Components/OnboardingBottomView.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/Components/OnboardingBottomView.swift
@@ -1,17 +1,21 @@
 import SwiftUI
 
 struct OnboardingBottomView: View {
+    let w: CGFloat
     let currentPage: Int
     let totalPages: Int
-    
     var nextAction: () -> Void
     
     var body: some View {
         VStack {
-            PageControlsView(currentPage: currentPage, totalPages: totalPages)
+            PageControlsView(
+                w: w,
+                currentPage: currentPage,
+                totalPages: totalPages
+            )
                 .padding(.bottom, 30)
             
-            NextButtonView(action: nextAction)
+            NextButtonView(w: w, action: nextAction)
         }
     }
 }

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/Components/PageControlsView.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/Components/PageControlsView.swift
@@ -1,20 +1,17 @@
 import SwiftUI
 
 struct PageControlsView: View {
-    
+    let w: CGFloat
     let currentPage: Int
     let totalPages: Int
-    
-    let activeColor = Color(red: 255/255, green: 114/255, blue: 116/255)
-    let inactiveColor = Color(red: 194/255, green: 194/255, blue: 194/255)
     
     var body: some View {
         HStack(spacing: 8) {
             ForEach(0..<totalPages, id: \.self) { index in
             Capsule()
-                    .fill(index == currentPage ? activeColor : inactiveColor)
+                    .fill(index == currentPage ? Color(UIColor.primary) : Color(UIColor.gray03))
                     .frame(width: index == currentPage ? 32 : 8,
-                           height: 8)
+                           height: (8 / 402) * w)
                     .cornerRadius(4)
             }
         }

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingContainerView.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingContainerView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct OnboardingContainerView: View {
+    let baseWidth: CGFloat = 402
+    
     @StateObject var viewModel: OnboardingViewModel
     
     init(viewModel: OnboardingViewModel) {
@@ -8,36 +10,41 @@ struct OnboardingContainerView: View {
     }
     
     var body: some View {
-        ZStack(alignment: .bottom) {
-            // 배경
-            Color(red: 248/255, green: 248/255, blue: 250/255)
-                .ignoresSafeArea()
-            
-            // 페이지 콘텐츠
-            ScrollView {
-                VStack {
-                    switch viewModel.currentPage {
-                    case 0: OnboardingView1()
-                    case 1: OnboardingView2()
-                    case 2: OnboardingView3()
-                    default: EmptyView()
+        GeometryReader { geo in
+            ZStack(alignment: .bottom) {
+                let w = geo.size.width
+                
+                // 배경
+                Color(UIColor.bg)
+                    .ignoresSafeArea()
+                
+                // 페이지 콘텐츠
+                ScrollView {
+                    VStack {
+                        switch viewModel.currentPage {
+                        case 0: OnboardingView1()
+                        case 1: OnboardingView2()
+                        case 2: OnboardingView3()
+                        default: EmptyView()
+                        }
+                        Spacer()
+                            .frame(height: (119 / baseWidth) * w)
                     }
-                    Spacer()
-                        .frame(height: 119)
                 }
-            }
-            .ignoresSafeArea(.container, edges: .bottom)
-            
-            // 하단 버튼
-            if viewModel.currentPage < viewModel.totalPages {
-                OnboardingBottomView(
-                    currentPage: viewModel.currentPage,
-                    totalPages: viewModel.totalPages,
-                    nextAction: {
-                        viewModel.nextButtonTapped()
-                    }
-                )
-                .padding(.bottom, 16)
+                .ignoresSafeArea(.container, edges: .bottom)
+                
+                // 하단 버튼
+                if viewModel.currentPage < viewModel.totalPages {
+                    OnboardingBottomView(
+                        w: w,
+                        currentPage: viewModel.currentPage,
+                        totalPages: viewModel.totalPages,
+                        nextAction: {
+                            viewModel.nextButtonTapped()
+                        }
+                    )
+                    .padding(.bottom, (16 / baseWidth) * w)
+                }
             }
         }
     }

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView1.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView1.swift
@@ -2,27 +2,34 @@ import SwiftUI
 
 struct OnboardingView1: View {
     
+    let baseWidth: CGFloat = 402
+    
     var body: some View {
-        VStack{
-            Spacer()
+        GeometryReader { geo in
+            let w = geo.size.width
             
-            Image("Onboarding1")
-                .resizable()
-                .frame(width: 200, height: 200)
-                .padding(.bottom, 32)
-            
-            Text("야구장 날씨가 궁금하시죠?")
-                .font(.custom("AppleSDGothicNeo-SemiBold", size: 28))
-                .padding(10)
-            
-            Text("좋아하는 구단을 선택하고,")
-                .font(.custom("AppleSDGothicNeo-Medium", size: 16))
-                .foregroundColor(Color(red: 143/255, green: 143/255, blue: 143/255))
-            
-            Text("구장별 날씨를 한눈에 확인하세요.")
-                .font(.custom("AppleSDGothicNeo-Medium", size: 16))
-                .foregroundColor(Color(red: 143/255, green: 143/255, blue: 143/255))
+            VStack {
+                Image("Onboarding1")
+                    .resizable()
+                    .frame(width: (200 / baseWidth) * w)
+                    .frame(height: (200 / baseWidth) * w)
+                    .padding(.bottom, (32 / baseWidth) * w)
+                
+                Text("야구장 날씨가 궁금하시죠?")
+                    .font(.custom("AppleSDGothicNeo-SemiBold", size: 28))
+                    .foregroundColor(Color(UIColor.appBlack))
+                    .padding((10 / baseWidth) * w)
+                
+                Text("좋아하는 구단을 선택하고,")
+                    .font(.custom("AppleSDGothicNeo-Medium", size: 16))
+                    .foregroundColor(Color(UIColor.gray05))
+                
+                Text("구장별 날씨를 한눈에 확인하세요.")
+                    .font(.custom("AppleSDGothicNeo-Medium", size: 16))
+                    .foregroundColor(Color(UIColor.gray05))
+            }
+            .frame(width: w)
+            .padding(.top, (165 / baseWidth) * w)
         }
-        .padding(.top, 165)
     }
 }

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView2.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView2.swift
@@ -2,24 +2,34 @@ import SwiftUI
 
 struct OnboardingView2: View {
     
+    let baseWidth: CGFloat = 402
+    
     var body: some View {
-        VStack{
-            Text("직관 순간을 기록해보세요!")
-                .font(.custom("AppleSDGothicNeo-SemiBold", size: 28))
-                .padding(10)
-            Text("사진과 텍스트로 편하게 기록하고,")
-                .font(.custom("AppleSDGothicNeo-Medium", size: 16))
-                .foregroundColor(Color(red: 143/255, green: 143/255, blue: 143/255))
-            
-            Text("기록들을 모아서 확인할 수 있어요.")
-                .font(.custom("AppleSDGothicNeo-Medium", size: 16))
-                .foregroundColor(Color(red: 143/255, green: 143/255, blue: 143/255))
-                .padding(.bottom, 32)
-            
-            Image("Onboarding2")
-                .resizable()
-                .frame(width: 200, height: 200)
+        GeometryReader { geo in
+            let w = geo.size.width
+            VStack{
+                Text("직관 순간을 기록해보세요!")
+                    .font(.custom("AppleSDGothicNeo-SemiBold", size: 28))
+                    .foregroundColor(Color(UIColor.appBlack))
+
+                    .padding((10 / baseWidth) * w)
+                
+                Text("사진과 텍스트로 편하게 기록하고,")
+                    .font(.custom("AppleSDGothicNeo-Medium", size: 16))
+                    .foregroundColor(Color(UIColor.gray05))
+
+                Text("기록들을 모아서 확인할 수 있어요.")
+                    .font(.custom("AppleSDGothicNeo-Medium", size: 16))
+                    .foregroundColor(Color(UIColor.gray05))
+                    .padding(.bottom, (32 / baseWidth) * w)
+                
+                Image("Onboarding2")
+                    .resizable()
+                    .frame(width: (200 / baseWidth) * w)
+                    .frame(height: (200 / baseWidth) * w)
+            }
+            .frame(width: w)
+            .padding(.top, (165 / baseWidth) * w)
         }
-        .padding(.top, 165)
     }
 }

--- a/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView3.swift
+++ b/YaguBogu/YaguBogu/Features/Onboarding/View/OnboardingView3.swift
@@ -2,25 +2,38 @@ import SwiftUI
 
 struct OnboardingView3: View {
     
+    let baseWidth: CGFloat = 402
+    
     var body: some View {
-        VStack {
-            HStack {
-                Text("경기 일정\n한눈에 모아봤어요.")
-                    .font(.custom("AppleSDGothicNeo-SemiBold", size: 28))
-                    .frame(width: 209)
-                
-                Image("Onboarding3")
-                    .resizable()
-                    .frame(width: 117, height: 115)
-            }
-            .frame(width: 332)
-            .padding(.bottom, 24)
+        GeometryReader { geo in
+            let w = geo.size.width
             
-            Image("Onboarding3_1")
-                .resizable()
-                .frame(width: 295, height: 304)
-                .cornerRadius(12)
+            VStack {
+                HStack {
+                    Text("경기 일정\n한눈에 모아봤어요.")
+                        .font(.custom("AppleSDGothicNeo-SemiBold", size: 28))
+                        .foregroundColor(Color(UIColor.appBlack))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(
+                            width: max((209 / baseWidth) * w, 230)
+                        )
+                    
+                    Image("Onboarding3")
+                        .resizable()
+                        .frame(width: (117 / baseWidth) * w)
+                        .frame(height: (115 / baseWidth) * w)
+                }
+                .frame(width: (332 / baseWidth) * w)
+                .padding(.bottom, (24 / baseWidth) * w)
+                
+                Image("Onboarding3_1")
+                    .resizable()
+                    .frame(width: (295 / baseWidth) * w)
+                    .frame(height: (302 / baseWidth) * w)
+                    .cornerRadius(12)
+            }
+            .frame(width: w)
+            .padding(.top, (80 / baseWidth) * w)
         }
-        .padding(.top, 80)
     }
 }


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #37 

- 기종에 따라 레이아웃이 달랐던 에러를 고치기 위해 **`GeometryReader`** 를 사용해 반응형 레이아웃으로 수정했습니다.
- 기준 디바이스는 아이폰 16 Pro로 하였고, 해당 기종의 화면 너비 (포인트 기준)는 402pt라서 `baseWidth`를 402로 했습니다. (기준 디바이스는 최신 기종으로 하는 것이 좋다고 해서 16 Pro로 선택)
<br>

<img width="1434" height="781" alt="image" src="https://github.com/user-attachments/assets/fa0a675a-8a76-4dc7-9eaa-645dcf04e401" />


# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

- Color를 `extension UIColor`에 지정되어 있는 색상들을 사용하게 수정했습니다!
+) 행간, 자간은 추후 수정하겠습니다. 그 때 서연님께서 피드백 주신 부분도 UIColor 적용하겠습니다!

# 관련 개발일지
[온보딩 화면 반응형 레이아웃으로 수정](https://www.notion.so/2b2b000d70fa80a98bbdd478a41faf73)


# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네 
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
