### PR TITLE
[Feat] #53 - 직관기록 데이터 유무로 화면 로직 구현

### DIFF
--- a/YaguBogu/YaguBogu/Features/Record/Model/CoreData/CoreData/CoreDataStack.swift
+++ b/YaguBogu/YaguBogu/Features/Record/Model/CoreData/CoreData/CoreDataStack.swift
@@ -51,16 +51,16 @@ extension CoreDataStack {
     
     private func createDummyData(context: NSManagedObjectContext) {
         
-        for i in 1...6 {
-            let newRecord = RecordData(context: context)
-            
-            newRecord.id = UUID()
-            newRecord.title = "테스트\(i)"
-            newRecord.homeScore = Int64(Int.random(in: 0...5))
-            newRecord.awayScore = Int64(Int.random(in: 0...5))
-            newRecord.gameDate = "2025-03-2\(i)"
-            
-        }
+//        for i in 1...6 {
+//            let newRecord = RecordData(context: context)
+//            
+//            newRecord.id = UUID()
+//            newRecord.title = "테스트\(i)"
+//            newRecord.homeScore = Int64(Int.random(in: 0...5))
+//            newRecord.awayScore = Int64(Int.random(in: 0...5))
+//            newRecord.gameDate = "2025-03-2\(i)"
+//            
+//        }
         
         saveContext()
     }

--- a/YaguBogu/YaguBogu/Features/Record/View/ListRecordView/RecordViewController.swift
+++ b/YaguBogu/YaguBogu/Features/Record/View/ListRecordView/RecordViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import SnapKit
 import RxSwift
 import RxCocoa
+import CoreData
 
 final class RecordViewController: BaseViewController {
     
@@ -50,19 +51,17 @@ final class RecordViewController: BaseViewController {
     
     override func configureUI() {
         super.configureUI()
-//        [emptyView].forEach{
-//            view.addSubview($0)
-//        }
-        [collectionView,floatingButton].forEach{
+        
+        [collectionView,emptyView,floatingButton].forEach{
             view.addSubview($0)
         }
     }
     
     override func setupConstraints() {
         super.setupConstraints()
-//        emptyView.snp.makeConstraints{ make in
-//            make.center.equalToSuperview()
-//        }
+        emptyView.snp.makeConstraints{ make in
+            make.center.equalToSuperview()
+        }
         collectionView.snp.makeConstraints { make in
             make.edges.equalTo(view.safeAreaLayoutGuide)
             
@@ -84,6 +83,15 @@ final class RecordViewController: BaseViewController {
             )) { index, data, cell in
                 cell.configure(with: data)
             }
+            .disposed(by: disposeBag)
+        
+        listViewModel.recordList
+            .map { $0.isEmpty }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] isEmpty in
+                self?.emptyView.isHidden = !isEmpty
+                self?.collectionView.isHidden = isEmpty
+            })
             .disposed(by: disposeBag)
         
         collectionView.rx.modelSelected(RecordData.self)
@@ -116,4 +124,5 @@ final class RecordViewController: BaseViewController {
         let layout = UICollectionViewCompositionalLayout(section: section)
         return layout
     }
+    
 }


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #53 

ListViewModel에서 [RecordData] 가 비어있을때 로직 추가
view의 isHidden을 이용하여 데이터가 있을때와 없을때 화면 처리

<img width="375" height="815" alt="simulator_screenshot_7B78BFC0-F96A-4670-A587-54BB4D2110DC" src="https://github.com/user-attachments/assets/b585aa74-1669-4004-9aff-49d770e6f590" />

<img width="375" height="815" alt="simulator_screenshot_EFF7A2E8-66DD-4524-BF28-2FEFA13147C9" src="https://github.com/user-attachments/assets/12a0cfa3-6e67-4994-969a-ee646f6f7453" />

# 질문 및 특이사항
> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

# 관련 개발로그
[개발로그 데이터  유무로 직관기록 화면표시](https://www.notion.so/2b5b000d70fa80b5a372eb197e516428?source=copy_link)

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
